### PR TITLE
Support New RM Commands

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -4,11 +4,9 @@ $subscriptionId = "Put Your Subscription Id Here";
 $location = "West Europe"
 
 
-Add-AzureAccount
+Login-AzureRmAccount
 
-Switch-AzureMode AzureResourceManager
+Set-AzureRmContext -SubscriptionId $subscriptionId
 
-Select-AzureSubscription -SubscriptionId $subscriptionId -Current
-
-New-AzureResourceGroup -ResourceGroupName $resourceGroupName -location $location `
--TemplateFile .\azuredeploy.json -TemplateParameterFile .\azuredeploy.parameters.json
+New-AzureRmResourceGroup -Name $resourceGroupName -Location $location
+New-AzureRmResourceGroupDeployment -ResourceGroupName $resourceGroupName -TemplateFile .\azuredeploy.json -TemplateParameterFile .\azuredeploy.parameters.json


### PR DESCRIPTION
Azure no longer supports the Switch-AzureMode command in favor of modified commandlets using (verb)-AzureRM(noun)
